### PR TITLE
Return 401 on expired token

### DIFF
--- a/app/Http/Controllers/V2/Announcement/AnnouncementController.php
+++ b/app/Http/Controllers/V2/Announcement/AnnouncementController.php
@@ -46,6 +46,11 @@ class AnnouncementController extends AuthorController
         $content_type = request()->header('Content-Type', '');
         $is_ical = $content_type == 'text/calendar';
 
+        // If user has a non valid token return a 401
+        if ($request->bearerToken() && !auth('api_v2')->check()) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
         // If user is logged in or inside university's wifi return all filtered announcements
         $local_ip = $request->session()->get('local_ip', 0);
 

--- a/app/Http/Controllers/V2/Authors/AuthorsController.php
+++ b/app/Http/Controllers/V2/Authors/AuthorsController.php
@@ -14,7 +14,12 @@ class AuthorsController extends Controller
     
     public function index(Request $request)
     {
-        
+
+        // If user has a non valid token return a 401
+        if ($request->bearerToken() && !auth('api_v2')->check()) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
         // If user is logged in or inside university's wifi return authors, filtering and then counting every announcement each one has
         $local_ip = $request->session()->get('local_ip', 0);                
         if ($local_ip == 1 or auth('api_v2')->check()) {

--- a/app/Http/Controllers/V2/Tag/TagController.php
+++ b/app/Http/Controllers/V2/Tag/TagController.php
@@ -86,6 +86,12 @@ class TagController extends Controller
      */
     public function indexForFiltering(Request $request)
     {
+
+        // If user has a non valid token return a 401
+        if ($request->bearerToken() && !auth('api_v2')->check()) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
         // If user is logged in or inside university's wifi return tags, filtering and then counting every announcement each one has with their children
         $local_ip = $request->session()->get('local_ip', 0);
         if ($local_ip == 1 or auth('api_v2')->check()) {

--- a/react_client/src/helpers/request.js
+++ b/react_client/src/helpers/request.js
@@ -55,15 +55,15 @@ class Request {
         return Promise.reject(error);
       });
 
-     this.axiosInstance.interceptors.response.use((rsp) => {
-       return rsp;
-     }, (rsp) => {
+      this.axiosInstance.interceptors.response.use((rsp) => {
+        return rsp;
+      }, (rsp) => {
         return rsp.response;
       })
       if(single){
         const path = url.includes("?") ? url.substr(0, url.indexOf("?")) : url;
         if(typeof this.request_instances[path] != "undefined"){
-            this.request_instances[path].cancel.cancel({message: "cancelled"})
+          this.request_instances[path].cancel.cancel({message: "cancelled"})
         }
         this.request_instances[path] = {
           fn: this.axiosInstance.bind(window, { method, url, baseURL, data, }),
@@ -183,10 +183,10 @@ class Request {
     let hasCanceled = false;
     const wrappedPromise = new Promise((resolve, reject) => {
       promise
-        .then(val => (hasCanceled ? reject({ isCanceled: true }) : resolve(val)))
-        .catch(
-          error => (hasCanceled ? reject({ isCanceled: true }) : reject(error))
-        );
+          .then(val => (hasCanceled ? reject({ isCanceled: true }) : resolve(val)))
+          .catch(
+              error => (hasCanceled ? reject({ isCanceled: true }) : reject(error))
+          );
     });
 
     return {

--- a/react_client/src/helpers/request.js
+++ b/react_client/src/helpers/request.js
@@ -1,12 +1,13 @@
 import axios from 'axios';
 import config from '../config';
 import storage from './storage';
+import cookieHelper from "./cookie";
 
 const baseURL = config.api_url;
 
 class Request {
 
-  
+
   constructor() {
     this.axiosInstance = axios.create({
       baseURL: baseURL,
@@ -33,7 +34,7 @@ class Request {
       });
 
       this.axiosInstance.interceptors.request.use( (config) => {
-    
+
         if( this.bearer ) {
           config.headers["Authorization"] = `Bearer ${this.bearer}`;
         }
@@ -41,15 +42,22 @@ class Request {
         if (multipart) {
           config.headers["Content-Type"] = `multipart/form-data`;
         }
-        
+
         return config;
-      }, function (error) {
-        return (error);
+     }, (error) => error);
+      this.axiosInstance.interceptors.response.use(
+          (rsp) => rsp, (error) => {
+            if (error.response && error.response.status === 401 && !error.config.url.includes('whoami')) {
+              cookieHelper.set('token', '');
+              storage.set('token', '');
+              window.location.reload();
+            }
+        return Promise.reject(error);
       });
-      
-      this.axiosInstance.interceptors.response.use((rsp) => {
-        return rsp;
-      }, (rsp) => {
+
+     this.axiosInstance.interceptors.response.use((rsp) => {
+       return rsp;
+     }, (rsp) => {
         return rsp.response;
       })
       if(single){
@@ -65,18 +73,18 @@ class Request {
       }else{
         return this.axiosInstance.bind(window, { method, url, baseURL, data, })
       }
-      
-      
+
+
     } else {
       return () => { new Promise((resolve) => resolve({ data })); };
     }
-  } 
+  }
 
   cancelAllRequests() {
     Object.keys(this.request_instances).forEach(path => {
       this.request_instances[path].cancel.cancel({message: "aborted"})
     })
-    
+
   }
 
   get(url, single = true) {
@@ -164,7 +172,7 @@ class Request {
     const httpRequest = this.createHttpRequest('GET', url, null, false);
 
     return httpRequest().then(async (httpResponse) => {
-      
+
       return httpResponse.data.login == true;
     }).catch((error, response) => {
       return error;

--- a/react_client/src/helpers/request.js
+++ b/react_client/src/helpers/request.js
@@ -48,8 +48,8 @@ class Request {
       this.axiosInstance.interceptors.response.use(
           (rsp) => rsp, (error) => {
             if (error.response && error.response.status === 401 && !error.config.url.includes('whoami')) {
-              cookieHelper.set('token', '');
-              storage.set('token', '');
+              cookieHelper.delete('token');
+              storage.set('token', null);
               window.location.reload();
             }
         return Promise.reject(error);


### PR DESCRIPTION
- Modified announcement, author, tag GET methods to return a 401 when an expired token is given
- Added an interceptor to handle 401 errors in web client and reload the page