### PR TITLE
Hotfix

### DIFF
--- a/react_client/src/App.js
+++ b/react_client/src/App.js
@@ -53,7 +53,7 @@ function App() {
   const checkLoginStatus = function () { 
     const c = cookieHelper.get('token')
     //console.log(c)
-    if (c && c !== '') {
+    if (c && c !== '' && c !== 'null') {
       storage.set('token', c)
       request.get('auth/whoami').then(response => {
         if (response.data && response.status === 200) {

--- a/react_client/src/helpers/request.js
+++ b/react_client/src/helpers/request.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import config from '../config';
 import storage from './storage';
-import cookieHelper from "./cookie";
 
 const baseURL = config.api_url;
 
@@ -46,20 +45,9 @@ class Request {
         return config;
      }, (error) => error);
       this.axiosInstance.interceptors.response.use(
-          (rsp) => rsp, (error) => {
-            if (error.response && error.response.status === 401 && !error.config.url.includes('whoami')) {
-              cookieHelper.delete('token');
-              storage.set('token', null);
-              window.location.reload();
-            }
-        return Promise.reject(error);
-      });
-
-      this.axiosInstance.interceptors.response.use((rsp) => {
-        return rsp;
-      }, (rsp) => {
-        return rsp.response;
-      })
+          (rsp) => rsp,
+          (error) => Promise.reject(error)
+      )
       if(single){
         const path = url.includes("?") ? url.substr(0, url.indexOf("?")) : url;
         if(typeof this.request_instances[path] != "undefined"){

--- a/react_client/src/helpers/request.js
+++ b/react_client/src/helpers/request.js
@@ -153,6 +153,8 @@ class Request {
     if (error.response && error.response.status === 401) {
       document.cookie = 'token=; Max-Age=-99999999;';
       storage.set('token', null)
+      this.cancelAllRequests();
+      window.location.assign('/');
     }
   }
 


### PR DESCRIPTION
- Reverted reload logic
- Configured axios to reject failed promises instead of swallowing the errors
- Configured the default error handler to cancel requests and navigate to "/" on error
- Prevented duplicated whoami request by properly checking the token value